### PR TITLE
feat: add Privacy Policy and Terms of Service pages to replace pdf

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,9 @@ import { Footer } from './components/utils/Footer';
 
 import { Error404 } from './components/utils/Error404';
 
+import { TermsOfService } from './components/legal/TermsOfService';
+import { PrivacyPolicy } from './components/legal/PrivacyPolicy';
+
 import { Projects } from './components/projects/Projects';
 
 function App(): JSX.Element {
@@ -43,6 +46,14 @@ function App(): JSX.Element {
                     <Community />
                     <PartnerSection />
                     <Donate />
+                    <Footer />
+                </Route>
+                <Route exact path="/tos">
+                    <TermsOfService />
+                    <Footer />
+                </Route>
+                <Route exact path="/privacy">
+                    <PrivacyPolicy />
                     <Footer />
                 </Route>
                 <Route component={Error404} />

--- a/src/components/legal/PrivacyPolicy.tsx
+++ b/src/components/legal/PrivacyPolicy.tsx
@@ -1,95 +1,108 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import BackgroundImage from '../../assets/img/discord.jpg';
-import { faShieldAlt } from '@fortawesome/free-solid-svg-icons';
+import { faUserShield, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
-export const PrivacyPolicy: React.FC = () => (
-    <>
-        <img className="relative z-0 object-cover w-screen h-screen opacity-20"
-            src={BackgroundImage} alt="" />
-        <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
-            <div className="relative my-auto xl:w-2/3 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
-                <FontAwesomeIcon className="mb-3 sm:mb-0 my-6" icon={faShieldAlt} size="9x" />
 
-                <div className="sm:space-x-10 mx-auto text-center md:text-left w-1/2">
-                    <div className="w-full divide-y divide-gray-400 sm:ml-10 space-y-2">
-                        <h1 className="text-7xl text-blue-light sm:text-8xl font-medium">
-                            Privacy Policy
-                        </h1>
+export const PrivacyPolicy: React.FC = () => {
+
+    const bodyRef = useRef<HTMLDivElement>(null);
+    const handleScroll = () => {
+        bodyRef.current?.scrollIntoView();
+    };
+
+    return (
+        <>
+            <img className="relative z-0 object-cover w-screen h-screen opacity-20 shadow-2xl"
+                src={BackgroundImage} alt="" />
+            <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
+                <div className="relative my-auto xl:w-3/4 md:w-4/5 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
+                    <FontAwesomeIcon className="mb-3 sm:mb-0 self-center" icon={faUserShield} size="7x" />
+
+                    <div className="sm:space-x-10 mx-auto text-center md:text-left w-1/2">
+                        <div className="w-full divide-y divide-gray-400 sm:ml-10 space-y-2">
+                            <h1 className="text-4xl md:text-7xl text-blue-light sm:text-8xl font-medium">
+                                Privacy Policy
+                            </h1>
+                        </div>
+                        <p className="text-xl mt-3">
+                            Please take some time to review our privacy policy.
+                            At flybywire simulations we make it a priority to be
+                            thoroughly transparent to our users about the data we collect and use.
+                        </p>
                     </div>
-                    <p className="text-xl mt-3">
-                        Please take some time to review our privacy policy.
-                        At flybywire simulations we make it a priority to be
-                        thoroughly transparent to our users about the data we collect and use.
-                    </p>
                 </div>
-            </div>
-        </div>
+                <FontAwesomeIcon onClick={handleScroll} className="absolute animate-bounce bottom-5 cursor-pointer" icon={faChevronDown} size="3x" />
 
-        <div className="w-auto mx-16 md:mx-auto my-40 max-w-6xl">
-            <h1 className="mt-40 text-6xl text-blue-light font-bold">Privacy Policy</h1>
-            <div className="mt-2">
-                <p>Effective: 21/12/2020</p>
-                <p>Author: Nathan Innes</p>
             </div>
-            <div className="w-0">
-                <a className="hover:text-blue-light underline" href="https://github.com/flybywiresim/manuals/raw/master/pdf/Privacy%20Policy.pdf" target="_blank" rel="noreferrer">
-                    <p>Download</p>
-                </a>
-            </div>
-            <div className="mt-10 ">
-                <h1 className="text-4xl text-blue-light-contrast font-bold">What information do we collect?</h1>
-                <div className="text-xl mt-4 leading-9 font-light">
-                    <p>We may collect, store and use the following kinds of personal data:</p>
-                    <p><br />1. Information about your visits to and use of this website;</p>
-                    <p>2. Information about any transactions carried out between you and us on or in relation to this website or any of our services including
-                        but not limited to Flybywire GitHub repositories, Discord and the in-game mod;</p>
-                    <p>3. Information that you provide to us for the purpose of registering with us, and/or subscribing to our website services and/or email
-                        notifications.</p>
+            {/* HandleScroll scrolls to this div */}
+            <div ref={bodyRef} />
+
+            <div className="w-full md:mx-auto px-20 xl:px-0 my-40 max-w-6xl">
+                <h1 className="mt-40 text-6xl text-blue-light font-bold">Privacy Policy</h1>
+                <div className="mt-2">
+                    <p>Effective: 21/12/2020</p>
+                    <p>Author: Nathan Innes</p>
                 </div>
-                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Information about website visits</h1>
-                <div className="text-xl mt-4 leading-9 font-light">
-                    <p>We may collect information about your visits to this website such as your IP address, geographical location, browser type, referral
-                    source, length of visit and number of page views. We may use this information in the administration of this website, to improve the
-                    website&apos;s usability, and for marketing purposes.
-                    </p>
-                    <p><br />We use cookies on this website. A cookie is a text file sent by a web server to a web browser, and stored by the browser. The text file
+                <div className="w-0">
+                    <a className="hover:text-blue-light underline" href="https://github.com/flybywiresim/manuals/raw/master/pdf/Privacy%20Policy.pdf" target="_blank" rel="noreferrer">
+                        <p>Download</p>
+                    </a>
+                </div>
+                <div className="mt-10 ">
+                    <h1 className="text-4xl text-blue-light-contrast font-bold">What information do we collect?</h1>
+                    <div className="text-xl mt-4 leading-9 font-light">
+                        <p>We may collect, store and use the following kinds of personal data:</p>
+                        <p><br />1. Information about your visits to and use of this website;</p>
+                        <p>2. Information about any transactions carried out between you and us on or in relation to this website or any of our services including
+                        but not limited to Flybywire GitHub repositories, Discord and the in-game mod;</p>
+                        <p>3. Information that you provide to us for the purpose of registering with us, and/or subscribing to our website services and/or email
+                        notifications.</p>
+                    </div>
+                    <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Information about website visits</h1>
+                    <div className="text-xl mt-4 leading-9 font-light">
+                        <p>We may collect information about your visits to this website such as your IP address, geographical location, browser type, referral
+                        source, length of visit and number of page views. We may use this information in the administration of this website, to improve the
+                        website&apos;s usability, and for marketing purposes.
+                        </p>
+                        <p><br />We use cookies on this website. A cookie is a text file sent by a web server to a web browser, and stored by the browser. The text file
                         is then sent back to the server each time the browser requests a page from the server. This enables the web server to identify and
                         track the web browser.</p>
-                    <p><br />We may send a cookie which may be stored by your browser on your computer&apos;s hard drive. We may use the information we obtain
+                        <p><br />We may send a cookie which may be stored by your browser on your computer&apos;s hard drive. We may use the information we obtain
                         from the cookie in the administration of this website, to improve the website&apos;s usability and for marketing purposes. We may also
                         use that information to recognise your computer when you visit our website, and to personalise our website for you.</p>
-                    <p><br />Most browsers allow you to refuse to accept cookies. (For example, in Internet Explorer you can refuse all cookie by clicking &quot;Tools&quot;,
+                        <p><br />Most browsers allow you to refuse to accept cookies. (For example, in Internet Explorer you can refuse all cookie by clicking &quot;Tools&quot;,
                         &quot;Internet Options&quot;, &quot;Privacy&quot;, and selecting &quot;Block all cookies&quot; using the sliding selector.) This will, however, have a negative impact
                         upon the usability of many websites.</p>
-                </div>
-                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Using your personal data</h1>
-                <div className="text-xl mt-4 leading-9 font-light">
-                    <p>Personal data submitted to this website will be used for the purposes specified in this privacy policy or in relevant parts of the website.
+                    </div>
+                    <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Using your personal data</h1>
+                    <div className="text-xl mt-4 leading-9 font-light">
+                        <p>Personal data submitted to this website will be used for the purposes specified in this privacy policy or in relevant parts of the website.
                         In addition to the uses identified elsewhere in this privacy policy, we may use your personal information to:</p>
-                    <p><br />1. Improve your browsing experience by personalising the website;</p>
-                    <p>2. Provide other organisations with statistical information about our users - but this information will not be used to identify any individual user.</p>
-                    <p><br />We will not without your express consent provide your personal information to any third parties for the purpose of direct marketing.</p>
-                </div>
-                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Other disclosures</h1>
-                <div className="text-xl mt-4 leading-9 font-light">
-                    <p>In addition to the disclosures reasonably necessary for the purposes identified elsewhere in this privacy policy, we may disclose information about you:</p>
-                    <p><br />1. To the extent that we are required to do so by law;</p>
-                    <p>2. In connection with any legal proceedings or prospective legal proceedings;</p>
-                    <p>3. In order to establish, exercise or defend our legal rights (including providing information to others for the purposes of fraud
+                        <p><br />1. Improve your browsing experience by personalising the website;</p>
+                        <p>2. Provide other organisations with statistical information about our users - but this information will not be used to identify any individual user.</p>
+                        <p><br />We will not without your express consent provide your personal information to any third parties for the purpose of direct marketing.</p>
+                    </div>
+                    <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Other disclosures</h1>
+                    <div className="text-xl mt-4 leading-9 font-light">
+                        <p>In addition to the disclosures reasonably necessary for the purposes identified elsewhere in this privacy policy, we may disclose information about you:</p>
+                        <p><br />1. To the extent that we are required to do so by law;</p>
+                        <p>2. In connection with any legal proceedings or prospective legal proceedings;</p>
+                        <p>3. In order to establish, exercise or defend our legal rights (including providing information to others for the purposes of fraud
                         prevention and reducing credit risk);</p>
-                    <p>4. Except as provided in this privacy policy, we will not provide your information to third parties.</p>
-                </div>
-                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Security of your personal data</h1>
-                <div className="text-xl mt-4 leading-9 font-light">
-                    <p>We will take reasonable precautions to prevent the loss, misuse or alteration of your personal information.
+                        <p>4. Except as provided in this privacy policy, we will not provide your information to third parties.</p>
+                    </div>
+                    <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Security of your personal data</h1>
+                    <div className="text-xl mt-4 leading-9 font-light">
+                        <p>We will take reasonable precautions to prevent the loss, misuse or alteration of your personal information.
                         Of course, data transmission over the internet is inherently insecure, and we cannot guarantee the security of data sent over the internet.</p>
-                </div>
-                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Third party websites</h1>
-                <div className="text-xl mt-4 leading-9 font-light">
-                    <p>The website contains links to other websites. We are not responsible for the privacy policies of third party websites.</p>
+                    </div>
+                    <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Third party websites</h1>
+                    <div className="text-xl mt-4 leading-9 font-light">
+                        <p>The website contains links to other websites. We are not responsible for the privacy policies of third party websites.</p>
+                    </div>
                 </div>
             </div>
-        </div>
-    </>
-);
+        </>
+    );
+};

--- a/src/components/legal/PrivacyPolicy.tsx
+++ b/src/components/legal/PrivacyPolicy.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import BackgroundImage from '../../assets/img/discord.jpg';
+import { faShieldAlt } from '@fortawesome/free-solid-svg-icons';
+
+export const PrivacyPolicy: React.FC = () => (
+    <>
+        <img className="relative z-0 object-cover w-screen h-screen opacity-20"
+            src={BackgroundImage} alt="" />
+        <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
+            <div className="relative my-auto xl:w-2/3 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
+                <FontAwesomeIcon className="mb-3 sm:mb-0 my-6" icon={faShieldAlt} size="9x" />
+
+                <div className="sm:space-x-10 mx-auto text-center md:text-left w-1/2">
+                    <div className="w-full divide-y divide-gray-400 sm:ml-10 space-y-2">
+                        <h1 className="text-7xl text-blue-light sm:text-8xl font-medium">
+                            Privacy Policy
+                        </h1>
+                    </div>
+                    <p className="text-xl mt-3">
+                        Please take some time to review our privacy policy.
+                        At flybywire simulations we make it a priority to be
+                        thoroughly transparent to our users about the data we collect and use.
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div className="w-auto mx-16 md:mx-auto my-40 max-w-6xl">
+            <h1 className="mt-40 text-6xl text-blue-light font-bold">Privacy Policy</h1>
+            <div className="mt-2">
+                <p>Effective: 21/12/2020</p>
+                <p>Author: Nathan Innes</p>
+            </div>
+            <div className="w-0">
+                <a className="hover:text-blue-light underline" href="https://github.com/flybywiresim/manuals/raw/master/pdf/Privacy%20Policy.pdf" target="_blank" rel="noreferrer">
+                    <p>Download</p>
+                </a>
+            </div>
+            <div className="mt-10 ">
+                <h1 className="text-4xl text-blue-light-contrast font-bold">What information do we collect?</h1>
+                <div className="text-xl mt-4 leading-9 font-light">
+                    <p>We may collect, store and use the following kinds of personal data:</p>
+                    <p><br />1. Information about your visits to and use of this website;</p>
+                    <p>2. Information about any transactions carried out between you and us on or in relation to this website or any of our services including
+                        but not limited to Flybywire GitHub repositories, Discord and the in-game mod;</p>
+                    <p>3. Information that you provide to us for the purpose of registering with us, and/or subscribing to our website services and/or email
+                        notifications.</p>
+                </div>
+                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Information about website visits</h1>
+                <div className="text-xl mt-4 leading-9 font-light">
+                    <p>We may collect information about your visits to this website such as your IP address, geographical location, browser type, referral
+                    source, length of visit and number of page views. We may use this information in the administration of this website, to improve the
+                    website&apos;s usability, and for marketing purposes.
+                    </p>
+                    <p><br />We use cookies on this website. A cookie is a text file sent by a web server to a web browser, and stored by the browser. The text file
+                        is then sent back to the server each time the browser requests a page from the server. This enables the web server to identify and
+                        track the web browser.</p>
+                    <p><br />We may send a cookie which may be stored by your browser on your computer&apos;s hard drive. We may use the information we obtain
+                        from the cookie in the administration of this website, to improve the website&apos;s usability and for marketing purposes. We may also
+                        use that information to recognise your computer when you visit our website, and to personalise our website for you.</p>
+                    <p><br />Most browsers allow you to refuse to accept cookies. (For example, in Internet Explorer you can refuse all cookie by clicking &quot;Tools&quot;,
+                        &quot;Internet Options&quot;, &quot;Privacy&quot;, and selecting &quot;Block all cookies&quot; using the sliding selector.) This will, however, have a negative impact
+                        upon the usability of many websites.</p>
+                </div>
+                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Using your personal data</h1>
+                <div className="text-xl mt-4 leading-9 font-light">
+                    <p>Personal data submitted to this website will be used for the purposes specified in this privacy policy or in relevant parts of the website.
+                        In addition to the uses identified elsewhere in this privacy policy, we may use your personal information to:</p>
+                    <p><br />1. Improve your browsing experience by personalising the website;</p>
+                    <p>2. Provide other organisations with statistical information about our users - but this information will not be used to identify any individual user.</p>
+                    <p><br />We will not without your express consent provide your personal information to any third parties for the purpose of direct marketing.</p>
+                </div>
+                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Other disclosures</h1>
+                <div className="text-xl mt-4 leading-9 font-light">
+                    <p>In addition to the disclosures reasonably necessary for the purposes identified elsewhere in this privacy policy, we may disclose information about you:</p>
+                    <p><br />1. To the extent that we are required to do so by law;</p>
+                    <p>2. In connection with any legal proceedings or prospective legal proceedings;</p>
+                    <p>3. In order to establish, exercise or defend our legal rights (including providing information to others for the purposes of fraud
+                        prevention and reducing credit risk);</p>
+                    <p>4. Except as provided in this privacy policy, we will not provide your information to third parties.</p>
+                </div>
+                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Security of your personal data</h1>
+                <div className="text-xl mt-4 leading-9 font-light">
+                    <p>We will take reasonable precautions to prevent the loss, misuse or alteration of your personal information.
+                        Of course, data transmission over the internet is inherently insecure, and we cannot guarantee the security of data sent over the internet.</p>
+                </div>
+                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Third party websites</h1>
+                <div className="text-xl mt-4 leading-9 font-light">
+                    <p>The website contains links to other websites. We are not responsible for the privacy policies of third party websites.</p>
+                </div>
+            </div>
+        </div>
+    </>
+);

--- a/src/components/legal/TermsOfService.tsx
+++ b/src/components/legal/TermsOfService.tsx
@@ -1,60 +1,72 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import BackgroundImage from '../../assets/img/discord.jpg';
-import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { faCogs, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
-export const TermsOfService: React.FC = () => (
-    <>
-        <img className="relative z-0 object-cover w-screen h-screen opacity-20"
-            src={BackgroundImage} alt="" />
-        <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
-            <div className="relative my-auto xl:w-2/3 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
-                <FontAwesomeIcon className="mb-3 sm:mb-0 my-4" icon={faBook} size="9x" />
+export const TermsOfService: React.FC = () => {
 
-                <div className="sm:space-x-10 mx-auto text-center md:text-left w-7/12">
-                    <div className="w-full divide-y divide-gray-400 sm:ml-10 space-y-2">
-                        <h1 className="text-7xl text-blue-light sm:text-8xl font-medium">
-                            Terms of Service
-                        </h1>
+    const bodyRef = useRef<HTMLDivElement>(null);
+    const handleScroll = () => {
+        bodyRef.current?.scrollIntoView();
+    };
+
+    return (
+        <>
+            <img className="relative z-0 object-cover w-screen h-screen opacity-20 shadow-2xl"
+                src={BackgroundImage} alt="" />
+            <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
+                <div className="relative my-auto xl:w-2/3 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
+                    <FontAwesomeIcon className="mb-3 sm:mb-0 self-center" icon={faCogs} size="7x" />
+                    <div className="sm:space-x-10 mx-auto text-center md:text-left w-7/12">
+                        <div className="w-full divide-y divide-gray-400 sm:ml-10 space-y-2">
+                            <h1 className="text-4xl md:text-7xl text-blue-light sm:text-8xl font-medium">
+                                Terms of Service
+                            </h1>
+                        </div>
+                        <p className="text-xl mt-3">
+                            Please take some time to review our terms of service.
+                            At flybywire simulations we make it a priority to ensure the legal and fair usage of software.
+                        </p>
                     </div>
-                    <p className="text-xl mt-3">
-                        Please take some time to review our terms of service.
-                        At flybywire simulations we make it a priority to ensure the legal and fair usage of software.
-                    </p>
                 </div>
-            </div>
-        </div>
-
-        <div className="w-auto mx-16 md:mx-auto my-40 max-w-6xl">
-            <h1 className="mt-40 text-6xl text-blue-light font-bold">Terms of Service</h1>
-            <div className="mt-2">
-                <p>Effective: 21/12/2020</p>
-                <p>Author: Nathan Innes</p>
-            </div>
-            <div className="w-0">
-                <a className="hover:text-blue-light underline" href="https://github.com/flybywiresim/manuals/raw/master/pdf/Terms%20of%20Service.pdf" target="_blank" rel="noreferrer">
-                    <p>Download</p>
-                </a>
+                <FontAwesomeIcon onClick={handleScroll} className="absolute animate-bounce bottom-5 cursor-pointer" icon={faChevronDown} size="3x" />
             </div>
 
-            <div className="mt-10 ">
-                <h1 className="text-4xl text-blue-light-contrast font-bold">Minimum Age Requirement</h1>
-                <p className="text-xl mt-4 leading-9 font-light">To protect the privacy of younger people it is very important that we implement an age restriction of <b>13 and
+            {/* HandleScroll scrolls to this div */}
+            <div ref={bodyRef} />
+
+            <div className="w-full md:mx-auto px-20 xl:px-0 my-40 max-w-6xl">
+                <h1 className="mt-40 text-6xl text-blue-light font-bold">Terms of Service</h1>
+                <div className="mt-2">
+                    <p>Effective: 21/12/2020</p>
+                    <p>Author: Nathan Innes</p>
+                </div>
+                <div className="w-0">
+                    <a className="hover:text-blue-light underline" href="https://github.com/flybywiresim/manuals/raw/master/pdf/Terms%20of%20Service.pdf" target="_blank" rel="noreferrer">
+                        <p>Download</p>
+                    </a>
+                </div>
+
+                <div className="mt-10 ">
+                    <h1 className="text-4xl text-blue-light-contrast font-bold">Minimum Age Requirement</h1>
+                    <p className="text-xl mt-4 leading-9 font-light">To protect the privacy of younger people it is very important that we implement an age restriction of <b>13 and
                     over</b> to join Flybywire Simulation services such as this website and Discord or any other communication
                     platform, other platforms may be subject to their own conditions. By using Flybywire Simulations services, you
                     agree that you are 13 years of age and the minimum age of digital consent in your country.
                     Flybywire Simulations reserve the right to remove users under the age of 13 and minimum age of digital consent
                     in any given case from communication platforms.</p>
-                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">User Complaint</h1>
-                <p className="text-xl mt-4 leading-9 font-light">In the event of a user should feel the need to make a complaint against another member, with regards to
+                    <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">User Complaint</h1>
+                    <p className="text-xl mt-4 leading-9 font-light">In the event of a user should feel the need to make a complaint against another member, with regards to
                 violating our <b>Terms of Service</b> or <b>Communication Platform Rules (Discord)</b>, they can contact the Moderation
                 team through Discord private message.
                 When writing the report please state the members name and what they are violating. All complaints will be
                     dealt with as professionally and as quickly as possible.</p>
-                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Legal Requirements</h1>
-                <p className="text-xl mt-4 leading-9 font-light">All users of Flybywire Simulations who choose to fly our mod must own a <b>legal</b> copy of Microsoft Flight Simulator (MSFS2020)</p>
+                    <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Legal Requirements</h1>
+                    <p className="text-xl mt-4 leading-9 font-light">All users of Flybywire Simulations who choose to fly our mod must own a <b>legal</b> copy of Microsoft Flight Simulator (MSFS2020)</p>
 
+                </div>
             </div>
-        </div>
-    </>
-);
+        </>
+    );
+
+};

--- a/src/components/legal/TermsOfService.tsx
+++ b/src/components/legal/TermsOfService.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import BackgroundImage from '../../assets/img/discord.jpg';
+import { faShieldAlt } from '@fortawesome/free-solid-svg-icons';
+
+export const TermsOfService: React.FC = () => (
+    <>
+        <img className="relative z-0 object-cover w-screen h-screen opacity-20"
+            src={BackgroundImage} alt="" />
+        <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
+            <div className="relative my-auto xl:w-2/3 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
+                <FontAwesomeIcon className="mb-3 sm:mb-0 my-16" icon={faShieldAlt} size="9x" />
+
+                <div className="sm:space-x-10 mx-auto text-center md:text-left w-1/2">
+                    <div className="w-full divide-y divide-gray-400 sm:ml-10 space-y-2">
+                        <h1 className="text-7xl text-blue-light sm:text-8xl font-medium">
+                            Terms of Service
+                        </h1>
+                    </div>
+                    <p className="text-xl mt-3">
+                        Please take some time to review our terms of service.
+                        At flybywire simulations we make it a priority to ensure the legal and fair usage of software.
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div className="w-auto mx-16 md:mx-auto my-40 max-w-6xl">
+            <h1 className="mt-40 text-6xl text-blue-light font-bold">Terms of Service</h1>
+            <div className="mt-2">
+                <p>Effective: 21/12/2020</p>
+                <p>Author: Nathan Innes</p>
+            </div>
+            <div className="w-0">
+                <a className="hover:text-blue-light underline" href="https://github.com/flybywiresim/manuals/raw/master/pdf/Terms%20of%20Service.pdf" target="_blank" rel="noreferrer">
+                    <p>Download</p>
+                </a>
+            </div>
+
+            <div className="mt-10 ">
+                <h1 className="text-4xl text-blue-light-contrast font-bold">Minimum Age Requirement</h1>
+                <p className="text-xl mt-4 leading-9 font-light">To protect the privacy of younger people it is very important that we implement an age restriction of <b>13 and
+                    over</b> to join Flybywire Simulation services such as this website and Discord or any other communication
+                    platform, other platforms may be subject to their own conditions. By using Flybywire Simulations services, you
+                    agree that you are 13 years of age and the minimum age of digital consent in your country.
+                    Flybywire Simulations reserve the right to remove users under the age of 13 and minimum age of digital consent
+                    in any given case from communication platforms.</p>
+                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">User Complaint</h1>
+                <p className="text-xl mt-4 leading-9 font-light">In the event of a user should feel the need to make a complaint against another member, with regards to
+                violating our <b>Terms of Service</b> or <b>Communication Platform Rules (Discord)</b>, they can contact the Moderation
+                team through Discord private message.
+                When writing the report please state the members name and what they are violating. All complaints will be
+                    dealt with as professionally and as quickly as possible.</p>
+                <h1 className="text-4xl mt-8 text-blue-light-contrast font-bold">Legal Requirements</h1>
+                <p className="text-xl mt-4 leading-9 font-light">All users of Flybywire Simulations who choose to fly our mod must own a <b>legal</b> copy of Microsoft Flight Simulator (MSFS2020)</p>
+
+            </div>
+        </div>
+    </>
+);

--- a/src/components/legal/TermsOfService.tsx
+++ b/src/components/legal/TermsOfService.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import BackgroundImage from '../../assets/img/discord.jpg';
-import { faShieldAlt } from '@fortawesome/free-solid-svg-icons';
+import { faBook } from '@fortawesome/free-solid-svg-icons';
 
 export const TermsOfService: React.FC = () => (
     <>
@@ -9,9 +9,9 @@ export const TermsOfService: React.FC = () => (
             src={BackgroundImage} alt="" />
         <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
             <div className="relative my-auto xl:w-2/3 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
-                <FontAwesomeIcon className="mb-3 sm:mb-0 my-16" icon={faShieldAlt} size="9x" />
+                <FontAwesomeIcon className="mb-3 sm:mb-0 my-4" icon={faBook} size="9x" />
 
-                <div className="sm:space-x-10 mx-auto text-center md:text-left w-1/2">
+                <div className="sm:space-x-10 mx-auto text-center md:text-left w-7/12">
                     <div className="w-full divide-y divide-gray-400 sm:ml-10 space-y-2">
                         <h1 className="text-7xl text-blue-light sm:text-8xl font-medium">
                             Terms of Service

--- a/src/components/utils/Footer.tsx
+++ b/src/components/utils/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Link } from 'react-router-dom';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faDiscord, faFacebook, faGithub, faTwitch, faTwitter, faYoutube } from '@fortawesome/free-brands-svg-icons';
 
@@ -9,11 +10,15 @@ type IconItemProp = {
 }
 
 export const FooterIconItem: React.FC<IconItemProp> = (props: PropsWithChildren<IconItemProp>) => {
-    return(
+    return (
         <a href={props.href} target="_blank" rel="noreferrer">
             <FontAwesomeIcon className="mx-2 hover:text-blue-light duration-100" icon={props.icon} size="lg" />
         </a>
     );
+};
+
+const scrollTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
 };
 
 export const Footer = (): JSX.Element => (
@@ -21,12 +26,12 @@ export const Footer = (): JSX.Element => (
         <div className="flex flex-row justify-center">
             <div className="flex flex-col">
                 <div className="flex flex-col-3 py-4 text-lg mx-auto">
-                    <FooterIconItem icon={faGithub} href="https://github.com/flybywiresim"/>
-                    <FooterIconItem icon={faTwitter} href="https://twitter.com/FlyByWireSim"/>
-                    <FooterIconItem icon={faFacebook} href="https://www.facebook.com/FlyByWireSimulations"/>
-                    <FooterIconItem icon={faDiscord} href="https://discord.gg/flybywire"/>
-                    <FooterIconItem icon={faTwitch} href="https://www.twitch.tv/flybywiresimulations"/>
-                    <FooterIconItem icon={faYoutube} href="https://www.youtube.com/c/FlyByWireSimulations"/>
+                    <FooterIconItem icon={faGithub} href="https://github.com/flybywiresim" />
+                    <FooterIconItem icon={faTwitter} href="https://twitter.com/FlyByWireSim" />
+                    <FooterIconItem icon={faFacebook} href="https://www.facebook.com/FlyByWireSimulations" />
+                    <FooterIconItem icon={faDiscord} href="https://discord.gg/flybywire" />
+                    <FooterIconItem icon={faTwitch} href="https://www.twitch.tv/flybywiresimulations" />
+                    <FooterIconItem icon={faYoutube} href="https://www.youtube.com/c/FlyByWireSimulations" />
                 </div>
                 <div className="text-center">
                     <div className="flex flex-row justify-center mx-auto space-x-8">
@@ -35,16 +40,16 @@ export const Footer = (): JSX.Element => (
                             target="_blank" rel="noreferrer">
                             <p>Source Code</p>
                         </a>
-                        <a className="hover:underline"
-                            href="https://github.com/flybywiresim/manuals/raw/master/pdf/Terms%20of%20Service.pdf"
-                            target="_blank" rel="noreferrer">
-                            <p>Terms of Service</p>
-                        </a>
-                        <a className="hover:underline"
-                            href="https://github.com/flybywiresim/manuals/raw/master/pdf/Privacy%20Policy.pdf"
-                            target="_blank" rel="noreferrer">
-                            <p>Privacy Policy</p>
-                        </a>
+                        <div className="hover:underline">
+                            <Link to='/tos'>
+                                <p onClick={scrollTop}>Terms of Service</p>
+                            </Link>
+                        </div>
+                        <div className="hover:underline">
+                            <Link to='/privacy'>
+                                <p onClick={scrollTop}>Privacy Policy</p>
+                            </Link>
+                        </div>
                     </div>
                     <p className="text-gray-400 pt-2">&copy; FlyByWire Simulations and its contributors 2020-2021</p>
                     <p className="text-sm text-gray-400 pt-2">v2.0</p>


### PR DESCRIPTION
This creates dedicated pages for both the terms of service and the privacy policy. This means that we no longer have to force the user to download a pdf to view either of them anymore. Still learning so the code might be really shaky or take some refactoring, but the code still works great on desktop and mobile. Even though this was meant to replace the PDF versions, they are still available for download on their respective pages.

Terms of Service:
![image](https://user-images.githubusercontent.com/30361843/108610340-95c7f700-739a-11eb-9fa8-f79f169e2368.png)

Privacy Policy: 
![image](https://user-images.githubusercontent.com/30361843/108610335-8ba5f880-739a-11eb-9f01-bcc7c7198dcd.png)



