### PR TITLE
fix: mobile navbar opacity

### DIFF
--- a/src/components/utils/NavBar.tsx
+++ b/src/components/utils/NavBar.tsx
@@ -21,7 +21,7 @@ export function NavBar(): JSX.Element {
     const [isOpen, setOpen] = useState(false);
 
     return (
-        <nav className={`fixed top-0 left-0 right-0 mx-auto py-2 z-50 ${scroll || isOpen ? 'transition bg-blue-dark-contrast shadow-lg-dark' : 'transition bg-blue-dark-contrast md:bg-transparent'}`}>
+        <nav className={`fixed top-0 left-0 right-0 mx-auto py-2 z-50 ${scroll || isOpen ? 'transition bg-blue-dark-contrast shadow-lg-dark' : 'transition bg-transparent'}`}>
             <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="relative flex items-center justify-between h-16">
                     <Link to="/">


### PR DESCRIPTION
I made the navbar transparent at the top of the header on mobile, on the new video, it is much easier to see on small devices.

BEFORE:
![image](https://user-images.githubusercontent.com/70278701/108605693-d49e8280-7383-11eb-882e-10fb5e52745f.png)

AFTER:
![image](https://user-images.githubusercontent.com/70278701/108605687-cea8a180-7383-11eb-8930-bd2b8a439aa6.png)
