### PR TITLE
fix: navbar margin

### DIFF
--- a/src/components/utils/Dropdown.tsx
+++ b/src/components/utils/Dropdown.tsx
@@ -12,7 +12,7 @@ export const Dropdown: React.FC<{ titleName?: string, className?: string }> = (p
     const [shown, setShown] = useState(false);
     return (
         <div className={`relative inline-block text-left ${props.className}`} onMouseEnter={() => setShown(true)} onMouseLeave={() => setShown(false)}>
-            <button draggable="false" type="button" onClick={() => setShown(old => !old)} className="inline-flex w-full px-4 py-2 text-xl text-white hover:text-blue-light transition-colors duration-200 focus:outline-none" id="options-menu" aria-haspopup="true" aria-expanded="true">
+            <button draggable="false" type="button" onClick={() => setShown(old => !old)} className="inline-flex w-full mt-1 px-4 py-2 text-xl text-white hover:text-blue-light transition-colors duration-200 focus:outline-none" id="options-menu" aria-haspopup="true" aria-expanded="true">
                 {props.titleName}
                 <FontAwesomeIcon className="h-5 w-5 self-center ml-1.5" icon={faChevronDown} size="xs" />
             </button>


### PR DESCRIPTION
## Summary of changes
Community section for NavBar had a gap so a margin has been added to compensate.

## Screenshots(if applicable)
![image](https://user-images.githubusercontent.com/18389085/110515836-bdd88980-8100-11eb-9fff-640cc3aa41c6.png)
