### PR TITLE
style: make projects text larger

### DIFF
--- a/src/components/projects/A32NX.tsx
+++ b/src/components/projects/A32NX.tsx
@@ -8,7 +8,7 @@ export const A32NX: React.FC = () => (
         <div className="absolute max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 inset-x-2 inset-y-1/3 z-30">
             <div className="flex flex-row justify-between items-end">
                 <div>
-                    <h2 className="text-xl font-medium tracking-widest text-white uppercase ml-2 mb-2">
+                    <h2 className="text-2xl font-medium tracking-widest text-white uppercase ml-2 mb-2">
                         DISCOVER THE
                     </h2>
                     <h1 className="text-7xl sm:text-8xl font-medium">


### PR DESCRIPTION
## Summary of changes
I made the "Discover The" text on the projects page larger.

## Screenshots(if applicable)
BEFORE:
![image](https://user-images.githubusercontent.com/70278701/110667036-db0c6700-8197-11eb-9f98-8edf9ae6c27a.png)

AFTER:
![image](https://user-images.githubusercontent.com/70278701/110667060-e069b180-8197-11eb-8752-daceaf2cd3f6.png)