### PR TITLE
fix: put back in line to show favicon on apple devices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
         }(window.location))
     </script>
     <!-- End Single Page Apps for GitHub Pages -->
-
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json"/>
     <title>FlyByWire Simulations</title>
 </head>


### PR DESCRIPTION
## Summary of changes
Sorry, I deleted a line which made the favicon not show on Apple devices. Short and sweet PR to put the line back in and have it point to the favicon location. 
