### PR TITLE
refactor: put a donate tab in drop down menu

### DIFF
--- a/src/components/utils/NavLinks.tsx
+++ b/src/components/utils/NavLinks.tsx
@@ -51,6 +51,9 @@ export const NavLinks: React.FC<NavLinksProps> = ({ className }) => (
             <DropdownItem>
                 <WebLink name="YouTube" external="https://www.youtube.com/FlyByWireSimulations" />
             </DropdownItem>
+            <DropdownItem>
+                <WebLink name="Donate" external="https://opencollective.com/flybywire/" />
+            </DropdownItem>
         </Dropdown>
     </div>
 );


### PR DESCRIPTION
## Summary of changes
Put a donate tab in the community drop-down menu that opens https://opencollective.com/flybywire in a new tab.

## Screenshots(if applicable)
![image](https://user-images.githubusercontent.com/62395728/114314217-0c3dc700-9ab7-11eb-889c-311ce46ec0af.png)

