### PR TITLE
fix: correct styling and layout errors

### DIFF
--- a/src/components/home/Donate.tsx
+++ b/src/components/home/Donate.tsx
@@ -6,7 +6,7 @@ import { Button } from '../Button';
 export const Donate: React.FC = () => (
     <section className="h-160 sm:h-120 flex flex-row items-center">
         <div className="absolute w-full z-10 flex flex-row justify-center">
-            <div className="w-3/4 xl:w-2/3 flex flex-col text-center xl:text-left">
+            <div className="md:w-3/4 xl:w-2/3 flex flex-col px-page text-center xl:text-left">
                 <div>
                     <h1 className="text-5xl text-teal font-extrabold">Donate</h1>
 

--- a/src/components/home/Download.tsx
+++ b/src/components/home/Download.tsx
@@ -31,7 +31,9 @@ export const Download: React.FC = () => {
                             <li className="ml-2 pl-2">One click install, neatly organized into one compact folder.</li>
                         </ul>
                     </div>
+
                     <div className="w-full lg:w-2/5 flex flex-col divide-y divide-gray-500">
+                        {/* Installer */}
                         <div className="pt-5 lg:pt-0 pb-5">
                             <span className="text-4xl text-blue-100">Installer</span>
                             <p className="mt-4 mb-6">
@@ -42,6 +44,8 @@ export const Download: React.FC = () => {
                                 <Button className="w-40 float-right bg-green-500 hover:bg-green-700 font-bold">Download</Button>
                             </a>
                         </div>
+
+                        {/* Direct Download */}
                         <div className="pt-5">
                             <span className="text-2xl text-blue-100">Direct Download</span>
                             <p className="mt-4 mb-6">If you prefer a direct download, the following links are available.</p>

--- a/src/components/home/Installer.tsx
+++ b/src/components/home/Installer.tsx
@@ -6,8 +6,8 @@ import { Button } from '../Button';
 import InstallerImage from '../../assets/img/InstallerScreenshot.png';
 
 export const Installer: React.FC = () => (
-    <section id="installer" className="relative w-screen flex flex-col 3xl:flex-row 3xl:justify-center items-center py-6 overflow-hidden bg-blue-dark">
-        <div className="mt-10 max-w-2xl flex flex-col items-center 3xl:items-start text-center 3xl:text-left 3xl:mb-20 3xl:mr-12 space-y-4">
+    <section id="installer" className="relative w-screen flex flex-col 3xl:flex-row 3xl:justify-center items-center px-page py-6 overflow-hidden bg-blue-dark">
+        <div className="mt-10 max-w-2xl flex flex-col items-center 3xl:items-start text-center 3xl:text-left mb-4 3xl:mb-20 3xl:mr-12 space-y-4">
             <div className="inline-flex items-center justify-center p-3 bg-blue-light-contrast rounded-md shadow-lg">
                 <FontAwesomeIcon icon={faBoxOpen} size="2x" />
             </div>
@@ -22,7 +22,7 @@ export const Installer: React.FC = () => (
                 <Button className="w-40 mt-4 bg-teal-light-contrast border-2 border-teal-light-contrast hover:bg-white hover:text-teal-light-contrast font-bold">Download</Button>
             </a>
         </div>
-        <div className="w-11/12 xl:w-5/6 3xl:w-320 -mb-48 3xl:mb-0">
+        <div className="w-11/12 xl:w-5/6 3xl:w-320 -mb-40 3xl:-mb-3">
             <img className="w-full" src={InstallerImage} alt="Installer" />
         </div>
     </section>

--- a/src/components/home/headers/A320Header.tsx
+++ b/src/components/home/headers/A320Header.tsx
@@ -12,7 +12,7 @@ export const A320Header: React.FC = () => {
     return (
         <>
             <header className="h-screen">
-                <div className="absolute max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 inset-x-2 inset-y-1/3 z-30 ">
+                <div className="absolute max-w-6xl mx-auto px-page inset-x-2 inset-y-1/3 z-30 ">
                     <h1 className="text-7xl sm:text-8xl font-medium pb-3">
                         <span className="text-blue-light">A32</span>
                         <span className="text-blue">N</span>

--- a/src/components/home/headers/A380Header.tsx
+++ b/src/components/home/headers/A380Header.tsx
@@ -11,7 +11,7 @@ export const A380Header: React.FC = () => {
     return (
         <>
             <header className="h-screen">
-                <div className="absolute max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 inset-x-2 inset-y-1/3 z-30 ">
+                <div className="absolute max-w-6xl mx-auto px-page inset-x-2 inset-y-1/3 z-30 ">
                     <h1 className="text-7xl sm:text-8xl font-medium pb-3">
                         <span className="text-blue-light">A380</span>
                         X

--- a/src/components/projects/A32NX/Download.tsx
+++ b/src/components/projects/A32NX/Download.tsx
@@ -14,7 +14,7 @@ export const Download: React.FC = () => {
         <section id="download" className="relative bg-blue-dark-contrast">
             <div className="w-full lg:w-11/12 2xl:w-4/6 m-auto px-10 py-14">
                 <div className="flex flex-col lg:flex-row">
-                    <div className="w-full lg:w-3/5 lg:pr-10">
+                    <div className="w-full lg:w-3/5 lg:pr-12">
                         <div className="text-left divide-y divide-gray-500 w-1/2 2xl:w-1/4">
                             <h2 className="text-base font-medium tracking-widest text-blue-200 uppercase">READY TO FLY?</h2>
                             <p className="mt-3 pt-3 text-5xl font-medium text-blue-light">
@@ -27,17 +27,18 @@ export const Download: React.FC = () => {
                             or you can download using standalone installations.
                         </p>
 
-                        <ul className="list-disc -m-2 pt-5 pl-5 text-lg text-gray-200">
+                        <ul className="list-disc -m-2 pt-7 pl-5 text-lg text-gray-200">
                             <li className="ml-2 pl-2">Integrates seamlessly into Microsoft Flight Simulator - no external programs required.</li>
                             <li className="ml-2 pl-2">Safe, trustworthy, and constantly updated to assure nothing is broken.</li>
                             <li className="ml-2 pl-2">One click install, neatly organized into one compact folder.</li>
                         </ul>
                     </div>
                     <div className="w-full lg:w-2/5 flex flex-col divide-y divide-gray-500">
-                        <div className="pt-5 lg:pt-0 pb-5">
+                        {/* Installer */}
+                        <div className="pt-16 lg:pt-0 pb-8">
                             <span className="text-4xl text-blue-100">Installer</span>
 
-                            <p className="mt-4 mb-6">
+                            <p className="max-w-prose mt-4 mb-6">
                                 Our easy-to-use installer is the easiest way to get started with our addons. Simply launch and install any addon you want, with only two clicks.
                             </p>
 
@@ -45,9 +46,11 @@ export const Download: React.FC = () => {
                                 <Button className="w-40 float-right bg-green-500 hover:bg-green-700 font-bold">Download</Button>
                             </a>
                         </div>
-                        <div className="pt-5">
+
+                        {/* Direct Download */}
+                        <div className="pt-7">
                             <span className="text-2xl text-blue-100">Direct Download</span>
-                            <p className="mt-4 mb-6">
+                            <p className="max-w-prose mt-4 mb-6">
                                 If you prefer a direct download, the following links are available.
                             </p>
 

--- a/src/components/projects/A32NX/ExtendedFeatures.tsx
+++ b/src/components/projects/A32NX/ExtendedFeatures.tsx
@@ -3,8 +3,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 
 export const ExtendedFeatures: React.FC = () => (
-    <section className="rounded-lg mx-auto px-4 py-4 max-w-screen-2xl sm:px-6 lg:px-8 pb-14">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 max-w-max mx-auto gap-x-14 gap-y-20 mt-10">
+    <section className="rounded-lg mx-auto px-page py-4 max-w-screen-2xl sm:px-6 lg:px-8 pb-20">
+        <div className="grid
+                        grid-cols-1
+                        md:grid-cols-2
+                        xl:grid-cols-3
+                        2xl:grid-cols-4
+                        max-w-max mx-auto gap-x-16 gap-y-20 mt-10"
+        >
             <Feature key="EFB">
                 <FeatureTitle>
                     Electronic Flight Bag
@@ -82,8 +88,8 @@ export const ExtendedFeatures: React.FC = () => (
 );
 
 const Feature: React.FC = (props) => (
-    <div className="w-80 flex flex-row">
-        <FontAwesomeIcon className="mb-auto mt-1 mr-4 text-green-500 text-2xl" size="1x" icon={faCheck} />
+    <div className="max-w-prose md:w-96 flex flex-row">
+        <FontAwesomeIcon className="mb-auto mt-1 mr-5 text-green-500 text-2xl" size="1x" icon={faCheck} />
         <div className="space-y-3">
             {props.children}
         </div>
@@ -94,6 +100,8 @@ const FeatureTitle: React.FC = (props) => (
     <h1 className="font-semibold text-2xl">{props.children}</h1>
 );
 
-const FeatureBody: React.FC = (props) => (
-    <p className="text-lg text-left">{props.children}</p>
+const FeatureBody: React.FC<{ className?: string }> = ({ children, className }) => (
+    <p className={`text-lg text-left ${className}`}>
+        {children}
+    </p>
 );

--- a/src/components/projects/A32NX/Features.tsx
+++ b/src/components/projects/A32NX/Features.tsx
@@ -4,7 +4,7 @@ import { CardBody, Card, CardTitle } from '../../utils/Card';
 
 export const Features = forwardRef<HTMLDivElement>((_, ref): JSX.Element => (
     <>
-        <div className="mx-auto divide-y divide-gray-500 max-w-2xl mt-12 px-4">
+        <div className="mx-auto divide-y divide-gray-500 max-w-2xl px-page mt-12">
             <p className="mt-3 mb-4 pt-3 text-5xl text-center font-medium text-blue-light">
                 Features
             </p>
@@ -14,26 +14,31 @@ export const Features = forwardRef<HTMLDivElement>((_, ref): JSX.Element => (
             </p>
         </div>
         <div id="features" className="bg-blue-darker bg-opacity-95 relative py-14">
-            <div className="rounded-lg mx-auto px-4 py-4 text-center sm:px-6 lg:px-0 lg:max-w-7xl">
+            <div className="rounded-lg mx-auto px-page lg:px-0 py-4 text-center lg:max-w-7xl">
                 <div className="mt-12">
-                    <div className="grid grid-cols-1 md:grid-cols-3 space-y-2 lg:justify-center divide-y md:divide-x md:divide-y-0 divide-gray-500">
+                    <div className="sm:w-2/3 xl:w-full mx-auto grid grid-cols-1 xl:grid-cols-3 space-y-2 xl:space-y-0 lg:justify-center divide-y xl:divide-x xl:divide-y-0 divide-gray-500">
                         <Card icon={faCogs}>
                             <CardTitle>Accurate System Functionality</CardTitle>
-                            <CardBody>Experimental versions of the A32NX include full rewrites of default autopilot and Fly-by-wire systems and much more.</CardBody>
+                            <CardBody className="max-w-prose mx-auto">
+                                Experimental versions of the A32NX include full rewrites of default autopilot and Fly-by-wire systems and much more.
+                            </CardBody>
                         </Card>
-                        <div className="pt-5 md:pt-0">
+                        <div className="pt-5 xl:pt-0">
                             <Card icon={faEye}>
                                 <CardTitle>Visual Fidelity</CardTitle>
-                                <CardBody>The A32NX is packaged with multiple visual reworks including new lighting, reworked textures, and model additions.</CardBody>
+                                <CardBody className="max-w-prose mx-auto">
+                                    The A32NX is packaged with multiple visual reworks including new lighting, reworked textures, and model additions.
+                                </CardBody>
                             </Card>
                         </div>
-                        <div className="pt-5 md:pt-0">
+                        <div className="pt-5 xl:pt-0">
                             <Card icon={faCheck}>
                                 <CardTitle>Verified by Real Pilots</CardTitle>
-                                <CardBody>The A32NX has been analyzed and tested by hundreds of real A320 pilots for accuracy to the real life aircraft.</CardBody>
+                                <CardBody className="max-w-prose mx-auto">
+                                    The A32NX has been analyzed and tested by hundreds of real A320 pilots for accuracy to the real life aircraft.
+                                </CardBody>
                             </Card>
                         </div>
-
                     </div>
                     <div ref={ref} />
                 </div>

--- a/src/components/projects/A32NX/Hero.tsx
+++ b/src/components/projects/A32NX/Hero.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../Button';
 
 export const Hero: React.FC = () => (
     <>
-        <header className="absolute max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 inset-x-2 inset-y-1/3 z-30">
+        <header className="absolute max-w-7xl mx-auto px-page inset-x-2 inset-y-1/3 z-30">
             <div className="flex flex-row justify-between items-end">
                 <div>
                     <h2 className="text-2xl font-medium tracking-widest text-white uppercase ml-2 mb-2">

--- a/src/components/utils/NavBar.tsx
+++ b/src/components/utils/NavBar.tsx
@@ -22,7 +22,7 @@ export function NavBar(): JSX.Element {
 
     return (
         <nav className={`fixed top-0 left-0 right-0 mx-auto py-2 z-50 ${scroll || isOpen ? 'transition bg-blue-dark-contrast shadow-lg-dark' : 'transition bg-transparent'}`}>
-            <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="max-w-6xl mx-auto px-page">
                 <div className="relative flex items-center justify-between h-16">
                     <Link to="/" onClick={scrollTop}>
                         <img className="subpixel-antialiased h-11 cursor-pointer" src={logo} alt="" />
@@ -35,7 +35,7 @@ export function NavBar(): JSX.Element {
                     </div>
                 </div>
             </div>
-            <NavLinks className={isOpen ? 'md:hidden' : 'hidden'} />
+            <NavLinks className={`px-page md:px-0 ${isOpen ? 'md:hidden' : 'hidden'}`} />
         </nav>
     );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,10 @@
       filter: grayscale(100%);
     }
   }
+
+  .px-page {
+    @apply px-5 md:px-8;
+  }
 }
 
 @font-face {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,6 @@ const reactComponentsSafeList = require('@flybywiresim/react-components/build/us
 
 module.exports = {
     purge: {
-        enabled: true,
         options: { safelist: [...reactComponentsSafeList] },
         content: [
             './src/**/*.{js,jsx,ts,tsx}',
@@ -35,5 +34,6 @@ module.exports = {
             },
         },
     },
+    // eslint-disable-next-line global-require
     plugins: [require('@flybywiresim/tailwind-config')],
 };


### PR DESCRIPTION
## Summary of changes

* Correct many styling inconsistencies
* Unify mobile/tablet margins with new `px-page` utility

## Screenshots

### Installer section

Before
![image](https://user-images.githubusercontent.com/4503241/114640238-a5c6cd80-9c9d-11eb-8fba-623edc52efdc.png)

After
![image](https://user-images.githubusercontent.com/4503241/114640224-9e072900-9c9d-11eb-86c7-56398813b48c.png)

### Donate section

#### Mobile

Before
![image](https://user-images.githubusercontent.com/4503241/114640062-554f7000-9c9d-11eb-8ce3-019a3eda6110.png)

After
![image](https://user-images.githubusercontent.com/4503241/114640076-5da7ab00-9c9d-11eb-9ec2-b1c285761631.png)

### A32NX > Download Links section

Before
![image](https://user-images.githubusercontent.com/4503241/114640155-7fa12d80-9c9d-11eb-93fb-cd05fde632aa.png)

After
![image](https://user-images.githubusercontent.com/4503241/114640139-76b05c00-9c9d-11eb-84d7-35e6ae0b9b8d.png)

### A32NX > Features section

#### Desktop

Before
![image](https://user-images.githubusercontent.com/4503241/114639940-0bff2080-9c9d-11eb-85da-240a98caf098.png)

After
![image](https://user-images.githubusercontent.com/4503241/114639957-17524c00-9c9d-11eb-8dbc-506a63e91ed2.png)

#### Mobile

Before
![image](https://user-images.githubusercontent.com/4503241/114640007-35b84780-9c9d-11eb-9780-93836dd94c16.png)

After
![image](https://user-images.githubusercontent.com/4503241/114640013-3bae2880-9c9d-11eb-99fd-28013ed7a7a5.png)

