### PR TITLE
refactor(partners): add -margin to push up temporary sim4flight png

### DIFF
--- a/components/home/PartnerSection.tsx
+++ b/components/home/PartnerSection.tsx
@@ -42,7 +42,8 @@ export function PartnerSection(): JSX.Element {
                     <PartnerImage className="w-3/5" src="img/partners/salty.svg" />
                 </Partner>
                 <Partner name="sim4flight" path="https://sim4flight.com/">
-                    <PartnerImage className="w-1/2" src="img/partners/s4f.png" />
+                    {/* TODO: Remove margin property when replacement SVG is available */}
+                    <PartnerImage className="w-1/2 -mt-10 lg:mt-0" src="img/partners/s4f.png" />
                 </Partner>
             </div>
         </section>


### PR DESCRIPTION
## Summary of changes
Adding a temporary negative top margin to account for the odd temporary sim4flight png we are currently using. 

## Screenshots(if applicable)
Before: 
![image](https://user-images.githubusercontent.com/30361843/116409783-ca708880-a7f9-11eb-85c2-a70b51d6398f.png)

After: 
![image](https://user-images.githubusercontent.com/30361843/116409714-bb89d600-a7f9-11eb-8adb-f799c7f0428d.png)
