### PR TITLE
fix: add cursor-pointer to remove text-selection cursor

### DIFF
--- a/components/utils/Footer.tsx
+++ b/components/utils/Footer.tsx
@@ -38,12 +38,12 @@ export const Footer = (): JSX.Element => (
                         >
                             <p>Source Code</p>
                         </a>
-                        <div className="hover:underline">
+                        <div className="hover:underline cursor-pointer">
                             <Link href="/tos">
                                 <p>Terms of Service</p>
                             </Link>
                         </div>
-                        <div className="hover:underline">
+                        <div className="hover:underline cursor-pointer">
                             <Link href="/privacy">
                                 <p>Privacy Policy</p>
                             </Link>


### PR DESCRIPTION
## Summary of changes
Add the cursor-pointer property to the divs enclosing both the tos and privacy links in the footer to get rid of the unwanted text-selection cursor that showed up before.

## Screenshots(if applicable)

