### PR TITLE
refactor(images): use next image optimization

### DIFF
--- a/components/home/Donate.tsx
+++ b/components/home/Donate.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 
 import { Button } from '../utils/Button';
 
@@ -28,10 +29,12 @@ export const Donate: React.FC = () => (
                 </div>
             </div>
         </div>
-
-        <img
-            className="relative z-0 h-160 sm:h-120 object-cover w-screen opacity-10"
-            src="img/donate.jpg"
-        />
+        <div className="relative z-0 h-160 sm:h-120 object-cover w-screen opacity-10">
+            <Image
+                src="/img/donate.jpg"
+                layout="fill"
+                objectFit="cover"
+            />
+        </div>
     </section>
 );

--- a/components/home/Installer.tsx
+++ b/components/home/Installer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBoxOpen } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '../utils/Button';
@@ -21,7 +22,7 @@ export const Installer: React.FC = () => (
             </a>
         </div>
         <div className="w-11/12 xl:w-5/6 3xl:w-320 -mb-40 3xl:-mb-3">
-            <img className="w-full" src="img/InstallerScreenshot.png" alt="Installer" />
+            <Image src="/img/InstallerScreenshot.png" alt="Installer" width={1200} height={850} quality={90} objectFit="contain" />
         </div>
     </section>
 );

--- a/components/home/PartnerSection.tsx
+++ b/components/home/PartnerSection.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from 'react';
+import Image from 'next/image';
 
 type ImageProps = {
     className?: string,
@@ -13,12 +14,12 @@ type PartnerProps = Partial<{
 
 export const PartnerImage: React.FC<ImageProps> = (props: PropsWithChildren<ImageProps>) => (
     <div className={`mx-auto ${props.className}`}>
-        <img src={props.src} alt="" />
+        <Image src={props.src} alt="" width={200} height={100} layout="responsive" objectFit="contain" />
     </div>
 );
 
 export const Partner: React.FC<PartnerProps> = (props: PropsWithChildren<PartnerProps>) => (
-    <div id={props.name} className={`flex flex-col justify-center ${props.className}`}>
+    <div id={props.name} className={`flex flex-col justify-center w-1/2 mx-auto ${props.className}`}>
         <a href={props.path} target="_blank" rel="noreferrer">
             {props.children}
         </a>
@@ -30,20 +31,20 @@ export function PartnerSection(): JSX.Element {
         <section className="bg-blue-dark w-full py-20 lg:py-8">
             <div className="max-w-screen-2xl grid md:grid-cols-1 lg:grid-cols-5 space-y-16 lg:space-y-0 items-center mx-auto">
                 <Partner name="Flightsim.to" path="https://flightsim.to/">
-                    <PartnerImage className="w-1/2" src="img/partners/flightsimto.png" />
+                    <PartnerImage src="/img/partners/flightsimto.png" />
                 </Partner>
                 <Partner name="FSNews" path="https://fsnews.eu/">
-                    <PartnerImage className="w-1/2" src="img/partners/fsnews.png" />
+                    <PartnerImage src="/img/partners/fsnews.png" />
                 </Partner>
                 <Partner name="YourControls" path="https://github.com/Sequal32/yourcontrols">
-                    <PartnerImage className="w-1/2" src="img/partners/yourcontrols.png" />
+                    <PartnerImage src="/img/partners/yourcontrols.png" />
                 </Partner>
                 <Partner name="SaltySimulations" path="https://sim4flight.com/salty/">
-                    <PartnerImage className="w-3/5" src="img/partners/salty.svg" />
+                    <PartnerImage src="/img/partners/salty.svg" />
                 </Partner>
                 <Partner name="sim4flight" path="https://sim4flight.com/">
                     {/* TODO: Remove margin property when replacement SVG is available */}
-                    <PartnerImage className="w-1/2 -mt-10 lg:mt-0" src="img/partners/s4f.png" />
+                    <PartnerImage src="/img/partners/s4f.png" />
                 </Partner>
             </div>
         </section>

--- a/components/utils/Footer.tsx
+++ b/components/utils/Footer.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Link from 'next/link';
+import Image from 'next/image';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faDiscord, faFacebook, faGithub, faTwitch, faTwitter, faYoutube } from '@fortawesome/free-brands-svg-icons';
 
@@ -57,7 +58,9 @@ export const Footer = (): JSX.Element => (
                             rel="noreferrer"
                         >
                             Powered by
-                            <img className="mx-2 h-4 self-center" src="/svg/vercel.svg" alt="Vercel" />
+                            <div className="mx-2">
+                                <Image src="/svg/vercel.svg" alt="Vercel" width={60} height={20} />
+                            </div>
                         </a>
                     </div>
 

--- a/components/utils/NavBar.tsx
+++ b/components/utils/NavBar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { Hamburger, NavLinks } from './NavLinks';
 
 export function NavBar(): JSX.Element {
@@ -20,7 +21,7 @@ export function NavBar(): JSX.Element {
             <div className="max-w-6xl mx-auto px-page">
                 <div className="relative flex items-center justify-between h-16">
                     <Link href="/">
-                        <img className="subpixel-antialiased h-11 cursor-pointer" src="/svg/white/FBW-Logo-WHITE.svg" alt="" />
+                        <Image className="cursor-pointer" src="/svg/white/FBW-Logo-WHITE.svg" width={180} height={40} />
                     </Link>
                     <div className="absolute inset-y-0 right-3 flex items-center md:hidden">
                         <Hamburger handleClick={() => setOpen((prevState) => !prevState)} />

--- a/pages/notams/[id].tsx
+++ b/pages/notams/[id].tsx
@@ -1,5 +1,6 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import React from 'react';
+import Image from 'next/image';
 import { getAllPostIds, getPostContent, PostContent } from '../../lib/notams/posts';
 
 export type PostProps = { content: PostContent }
@@ -7,12 +8,15 @@ export type PostProps = { content: PostContent }
 const Post: React.FC<PostProps> = ({ content: { authors, category, contentHtml, date, readingStats, title, metaImage, metaAlt } }) => (
     <div className="min-h-screen w-full mx-auto bg-gradient-to-b from-white to-gray-100 pb-6">
         <div className="h-160 bg-blue-dark overflow-hidden shadow-md">
-            <img
-                draggable="false"
-                className="absolute filter blur-sm opacity-20 w-screen h-160 object-cover"
-                src={metaImage}
-                alt={metaAlt}
-            />
+            <div className="absolute filter blur-sm opacity-20 w-screen h-160">
+                <Image
+                    layout="fill"
+                    objectFit="cover"
+                    draggable="false"
+                    src={metaImage}
+                    alt={metaAlt}
+                />
+            </div>
             <div className="flex flex-col relative h-160 max-w-6xl 2xl:inset-x-80 justify-end pb-8 lg:pb-14 px-page">
                 <div className="flex flex-row items-center text-xl">
                     {category === 'ANNOUNCEMENTS'

--- a/pages/notams/index.tsx
+++ b/pages/notams/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GetStaticProps } from 'next';
 import Link from 'next/link';
+import Image from 'next/image';
 import { getPostListings, PostListing } from '../../lib/notams/posts';
 
 export type BlogProps = { listings: PostListing[] }
@@ -37,9 +38,11 @@ const Blog: React.FC<BlogProps> = ({ listings }) => (
                     >
                         {metaImage
                             ? (
-                                <img
+                                <Image
+                                    width={1000}
+                                    height={350}
+                                    objectFit="cover"
                                     draggable="false"
-                                    className="max-h-80 object-cover"
                                     src={metaImage}
                                     alt={metaAlt}
                                 />

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import Image from 'next/image';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserShield, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
@@ -11,11 +12,14 @@ const Privacy: React.FC = () => {
     return (
         <>
             <header>
-                <img
-                    className="relative z-0 object-cover w-screen h-screen opacity-20 shadow-2xl"
-                    src="/img/a32nxwing.png"
-                    alt=""
-                />
+                <div className="relative z-0 object-cover w-screen h-screen opacity-20 shadow-2xl">
+                    <Image
+                        src="/img/a32nxwing.png"
+                        alt="Privacy policy"
+                        layout="fill"
+                        objectFit="cover"
+                    />
+                </div>
                 <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
                     <div className="relative my-auto xl:w-3/4 md:w-4/5 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
                         <FontAwesomeIcon className="mb-3 sm:mb-0 self-center" icon={faUserShield} size="7x" />

--- a/pages/tos.tsx
+++ b/pages/tos.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import Image from 'next/image';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCogs, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
@@ -11,11 +12,14 @@ const Tos: React.FC = () => {
     return (
         <>
             <header>
-                <img
-                    className="relative z-0 object-cover w-screen h-screen opacity-20 shadow-2xl"
-                    src="/img/a32nxwing.png"
-                    alt=""
-                />
+                <div className="relative z-0 object-cover w-screen h-screen opacity-20 shadow-2xl">
+                    <Image
+                        src="/img/a32nxwing.png"
+                        alt="Terms of Service"
+                        layout="fill"
+                        objectFit="cover"
+                    />
+                </div>
                 <div className="absolute top-0 bottom-0 z-20 w-full flex justify-center">
                     <div className="relative my-auto xl:w-2/3 justify-center xl:justify-start text-center sm:flex sm:item-center sm:divide-x sm:space-x-10">
                         <FontAwesomeIcon className="mb-3 sm:mb-0 self-center" icon={faCogs} size="7x" />


### PR DESCRIPTION
Fixes N/A

## Summary of changes
+ All images converted to NextJS image optimization. 

This PR improves the performance of the website by cutting the size of images to only what is necessary and doesn't lose that much quality.

This PR requires either Vercel to host the page or we would require an image loader service to get ```next/image``` to work. 