### PR TITLE
style: add css classes to ensure smooth and responsive iframe embeds

### DIFF
--- a/styles/iframe.scss
+++ b/styles/iframe.scss
@@ -1,0 +1,14 @@
+.responsive-container {
+  position: relative;
+  overflow: hidden;
+  padding-top: 56.25%
+}
+
+.responsive-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -1,3 +1,4 @@
 @use 'tailwind';
 @use 'scrollbar';
 @use 'swiper';
+@use 'iframe';


### PR DESCRIPTION
## Summary of changes
Adds CSS classes, one to be used on the containing div of an iframe, and one to be used on the iframe itself. These classes ensure that the iframe will scale responsively and remain within the main blog area.

## Screenshots(if applicable)
With: 
![image](https://user-images.githubusercontent.com/30361843/117987355-03335600-b300-11eb-82cd-f550f59e38a6.png)

Without😒:
![image](https://user-images.githubusercontent.com/30361843/117987258-ed259580-b2ff-11eb-80bc-85b2988ad202.png)

## Usage
Within markdown files, use the classes as such:

```html
<div class="responsive-container">
  <iframe 
     class="responsive-iframe" 
     src="https://www.youtube-nocookie.com/embed/YH0iAGiXkHE" 
     title="YouTube video player" frameborder="0" allow="accelerometer; 
     autoplay; clipboard-write; encrypted-media; gyroscope; 
     picture-in-picture" allowfullscreen>
  </iframe>
</div>