### PR TITLE
refactor: add padding so the article content isn't so close to header/footer

### DIFF
--- a/pages/notams/[id].tsx
+++ b/pages/notams/[id].tsx
@@ -51,7 +51,7 @@ const Post: React.FC<PostProps> = ({ content: { authors, category, contentHtml, 
         </div>
 
         <article
-            className="flex flex-col mx-auto px-page pt-16 pb-16 my-8 max-w-6xl space-y-4 text-xl text-black prose-2xl prose lg:text-justify"
+            className="flex flex-col mx-auto px-page py-16 my-8 max-w-6xl space-y-4 text-xl text-black prose-2xl prose lg:text-justify"
             /* eslint-disable-next-line react/no-danger */
             dangerouslySetInnerHTML={{ __html: contentHtml }}
         />

--- a/pages/notams/[id].tsx
+++ b/pages/notams/[id].tsx
@@ -51,7 +51,7 @@ const Post: React.FC<PostProps> = ({ content: { authors, category, contentHtml, 
         </div>
 
         <article
-            className="flex flex-col mx-auto px-page my-8 max-w-6xl space-y-4 text-xl text-black prose-2xl prose lg:text-justify"
+            className="flex flex-col mx-auto px-page pt-16 pb-16 my-8 max-w-6xl space-y-4 text-xl text-black prose-2xl prose lg:text-justify"
             /* eslint-disable-next-line react/no-danger */
             dangerouslySetInnerHTML={{ __html: contentHtml }}
         />


### PR DESCRIPTION
## Summary of changes
Adds padding to article so that it isn't so close to the header and footer

## Screenshots(if applicable)
Before: 
![image](https://user-images.githubusercontent.com/30361843/118060780-2d653200-b359-11eb-9cd2-02f5c052e6c6.png)

After:
![image](https://user-images.githubusercontent.com/30361843/118060805-3d7d1180-b359-11eb-9ded-69f5411920f4.png)

