### PR TITLE
refactor: make preview images undraggable on NOTAMS main page

### DIFF
--- a/pages/notams/index.tsx
+++ b/pages/notams/index.tsx
@@ -38,6 +38,7 @@ const Blog: React.FC<BlogProps> = ({ listings }) => (
                         {metaImage
                             ? (
                                 <img
+                                    draggable="false"
                                     className="max-h-80 object-cover"
                                     src={metaImage}
                                     alt={metaAlt}


### PR DESCRIPTION
## Summary of changes
Make preview images undraggable on NOTAMS main page

## Screenshots(if applicable)
