### PR TITLE
feat: add conditional rendering for exp download

### DIFF
--- a/src/components/projects/A32NX/Download.tsx
+++ b/src/components/projects/A32NX/Download.tsx
@@ -66,12 +66,12 @@ export const Download = () => {
                                         <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
                                     </a>
                                 </div>
-                                <div className="flex flex-row justify-between items-center pt-5 mb-8">
+                                {/* <div className="flex flex-row justify-between items-center pt-5 mb-8">
                                     <span className="text-xl text-gray-300">Experimental Build</span>
                                     <a href={getDownloadLink(urls.exp)}>
                                         <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
                                     </a>
-                                </div>
+                                </div> */}
                             </div>
                         </div>
                     </div>

--- a/src/components/projects/A32NX/Download.tsx
+++ b/src/components/projects/A32NX/Download.tsx
@@ -1,6 +1,10 @@
 import { Button } from '../../utils/Button';
 
-export const Download = () => {
+type DownloadProps = {
+    expOnHold?: boolean
+}
+
+export const Download = ({ expOnHold }: DownloadProps) => {
     const urls = {
         stable: 'https://flybywiresim-packages.b-cdn.net/stable/A32NX-stable.zip',
         dev: 'https://flybywiresim-packages.b-cdn.net/vmaster/A32NX-master.zip',
@@ -9,6 +13,82 @@ export const Download = () => {
 
     const getDownloadLink = (link: string) => `https://api.flybywiresim.com/api/v1/download?url=${link}`;
 
+    if (expOnHold) {
+        return (
+            <section id="download" className="relative bg-blue-dark-contrast">
+                <div className="py-14 px-10 m-auto w-full lg:w-11/12 2xl:w-4/6">
+                    <div className="flex flex-col lg:flex-row">
+                        <div className="w-full lg:pr-12 lg:w-3/5">
+                            <div className="w-1/2 text-left divide-y divide-gray-500 2xl:w-1/4">
+                                <h2 className="text-base font-medium tracking-widest text-blue-200 uppercase">READY TO FLY?</h2>
+                                <p className="pt-3 mt-3 text-5xl font-medium text-blue-light">
+                                    Download
+                                </p>
+                            </div>
+
+                            <p className="mt-5 max-w-prose text-xl">
+                                We have included many options to download our addons, you can use our custom and simple installer to always keep your products up to date,
+                                or you can download using standalone installations.
+                            </p>
+
+                            <ul className="pt-7 pl-5 -m-2 text-lg list-disc text-gray-200">
+                                <li className="pl-2 ml-2">Integrates seamlessly into Microsoft Flight Simulator - no external programs required.</li>
+                                <li className="pl-2 ml-2">Safe, trustworthy, and constantly updated to assure nothing is broken.</li>
+                                <li className="pl-2 ml-2">One click install, neatly organized into one compact folder.</li>
+                            </ul>
+                        </div>
+                        <div className="flex flex-col w-full divide-y divide-gray-500 lg:w-2/5">
+                            {/* Installer */}
+                            <div className="pt-16 pb-8 lg:pt-0">
+                                <span className="text-4xl text-blue-100">Installer</span>
+
+                                <p className="mt-4 mb-6 max-w-prose">
+                                    Our easy-to-use installer is the easiest way to get started with our addons. Simply launch and install any addon you want, with only two clicks.
+                                </p>
+
+                                <a href="https://api.flybywiresim.com/installer">
+                                    <Button className="float-right w-40 font-bold bg-green-500 hover:bg-green-700">Download</Button>
+                                </a>
+                            </div>
+
+                            {/* Direct Download */}
+                            <div className="pt-7">
+                                <span className="text-2xl text-blue-100">Direct Download</span>
+                                <p className="mt-4 mb-6 max-w-prose">
+                                    If you prefer a direct download, the following links are available.
+                                </p>
+
+                                <div className="divide-y divide-gray-700">
+                                    <div className="flex flex-row justify-between items-center mb-5">
+                                        <span className="text-xl text-gray-300">Stable Release</span>
+                                        <a href={getDownloadLink(urls.stable)}>
+                                            <Button className="float-right w-40 font-bold bg-green-500 hover:bg-green-700">Download</Button>
+                                        </a>
+                                    </div>
+                                    <div className="flex flex-row justify-between items-center pt-5 mb-5">
+                                        <span className="text-xl text-gray-300">Development Build</span>
+                                        <a href={getDownloadLink(urls.dev)}>
+                                            <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
+                                        </a>
+                                    </div>
+                                    <div />
+                                </div>
+                                <div className="flex flex-row justify-between items-center pt-5 mb-5">
+                                    <span className="text-xl text-gray-300">Experimental Build</span>
+                                    <Button className="float-right w-40 font-bold bg-blue-light-contrast opacity-30 cursor-not-allowed">On Hold</Button>
+                                </div>
+                                <span className="flex-wrap mb-8 text-gray-300">
+                                    Our experimental branch is temporarily
+                                    <a href="https://docs.flybywiresim.com/fbw-a32nx/support/exp/" className="text-blue-light">&#32;on hold&#32;</a>
+                                    and all of its features have been moved to the development build.
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        );
+    }
     return (
         <section id="download" className="relative bg-blue-dark-contrast">
             <div className="py-14 px-10 m-auto w-full lg:w-11/12 2xl:w-4/6">
@@ -66,12 +146,12 @@ export const Download = () => {
                                         <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
                                     </a>
                                 </div>
-                                {/* <div className="flex flex-row justify-between items-center pt-5 mb-8">
+                                <div className="flex flex-row justify-between items-center pt-5 mb-8">
                                     <span className="text-xl text-gray-300">Experimental Build</span>
                                     <a href={getDownloadLink(urls.exp)}>
                                         <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
                                     </a>
-                                </div> */}
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/components/projects/A32NX/Download.tsx
+++ b/src/components/projects/A32NX/Download.tsx
@@ -13,82 +13,6 @@ export const Download = ({ expOnHold }: DownloadProps) => {
 
     const getDownloadLink = (link: string) => `https://api.flybywiresim.com/api/v1/download?url=${link}`;
 
-    if (expOnHold) {
-        return (
-            <section id="download" className="relative bg-blue-dark-contrast">
-                <div className="py-14 px-10 m-auto w-full lg:w-11/12 2xl:w-4/6">
-                    <div className="flex flex-col lg:flex-row">
-                        <div className="w-full lg:pr-12 lg:w-3/5">
-                            <div className="w-1/2 text-left divide-y divide-gray-500 2xl:w-1/4">
-                                <h2 className="text-base font-medium tracking-widest text-blue-200 uppercase">READY TO FLY?</h2>
-                                <p className="pt-3 mt-3 text-5xl font-medium text-blue-light">
-                                    Download
-                                </p>
-                            </div>
-
-                            <p className="mt-5 max-w-prose text-xl">
-                                We have included many options to download our addons, you can use our custom and simple installer to always keep your products up to date,
-                                or you can download using standalone installations.
-                            </p>
-
-                            <ul className="pt-7 pl-5 -m-2 text-lg list-disc text-gray-200">
-                                <li className="pl-2 ml-2">Integrates seamlessly into Microsoft Flight Simulator - no external programs required.</li>
-                                <li className="pl-2 ml-2">Safe, trustworthy, and constantly updated to assure nothing is broken.</li>
-                                <li className="pl-2 ml-2">One click install, neatly organized into one compact folder.</li>
-                            </ul>
-                        </div>
-                        <div className="flex flex-col w-full divide-y divide-gray-500 lg:w-2/5">
-                            {/* Installer */}
-                            <div className="pt-16 pb-8 lg:pt-0">
-                                <span className="text-4xl text-blue-100">Installer</span>
-
-                                <p className="mt-4 mb-6 max-w-prose">
-                                    Our easy-to-use installer is the easiest way to get started with our addons. Simply launch and install any addon you want, with only two clicks.
-                                </p>
-
-                                <a href="https://api.flybywiresim.com/installer">
-                                    <Button className="float-right w-40 font-bold bg-green-500 hover:bg-green-700">Download</Button>
-                                </a>
-                            </div>
-
-                            {/* Direct Download */}
-                            <div className="pt-7">
-                                <span className="text-2xl text-blue-100">Direct Download</span>
-                                <p className="mt-4 mb-6 max-w-prose">
-                                    If you prefer a direct download, the following links are available.
-                                </p>
-
-                                <div className="divide-y divide-gray-700">
-                                    <div className="flex flex-row justify-between items-center mb-5">
-                                        <span className="text-xl text-gray-300">Stable Release</span>
-                                        <a href={getDownloadLink(urls.stable)}>
-                                            <Button className="float-right w-40 font-bold bg-green-500 hover:bg-green-700">Download</Button>
-                                        </a>
-                                    </div>
-                                    <div className="flex flex-row justify-between items-center pt-5 mb-5">
-                                        <span className="text-xl text-gray-300">Development Build</span>
-                                        <a href={getDownloadLink(urls.dev)}>
-                                            <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
-                                        </a>
-                                    </div>
-                                    <div />
-                                </div>
-                                <div className="flex flex-row justify-between items-center pt-5 mb-5">
-                                    <span className="text-xl text-gray-300">Experimental Build</span>
-                                    <Button className="float-right w-40 font-bold bg-blue-light-contrast opacity-30 cursor-not-allowed">On Hold</Button>
-                                </div>
-                                <span className="flex-wrap mb-8 text-gray-300">
-                                    Our experimental branch is temporarily
-                                    <a href="https://docs.flybywiresim.com/fbw-a32nx/support/exp/" className="text-blue-light">&#32;on hold&#32;</a>
-                                    and all of its features have been moved to the development build.
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-        );
-    }
     return (
         <section id="download" className="relative bg-blue-dark-contrast">
             <div className="py-14 px-10 m-auto w-full lg:w-11/12 2xl:w-4/6">
@@ -146,13 +70,38 @@ export const Download = ({ expOnHold }: DownloadProps) => {
                                         <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
                                     </a>
                                 </div>
-                                <div className="flex flex-row justify-between items-center pt-5 mb-8">
-                                    <span className="text-xl text-gray-300">Experimental Build</span>
-                                    <a href={getDownloadLink(urls.exp)}>
-                                        <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
-                                    </a>
-                                </div>
+                                <div />
                             </div>
+                            {expOnHold
+                                ? (
+                                    <>
+                                        <div className="flex flex-row justify-between items-center pt-5 mb-5">
+                                            <span className="text-xl text-gray-300">Experimental Build</span>
+                                            <Button className="float-right w-40 font-bold bg-blue-light-contrast opacity-30 cursor-not-allowed">On Hold</Button>
+                                        </div>
+                                        <span className="flex-wrap mb-8 text-gray-300">
+                                            Our experimental branch is temporarily
+                                            <a href="https://docs.flybywiresim.com/fbw-a32nx/support/exp/" className="text-blue-light">&#32;on hold&#32;</a>
+                                            and all of its features have been moved to the development build.
+                                        </span>
+                                    </>
+                                )
+                                : (
+                                    <>
+                                        <div className="flex flex-row justify-between items-center pt-5 mb-5">
+                                            <span className="text-xl text-gray-300">Development Build</span>
+                                            <a href={getDownloadLink(urls.dev)}>
+                                                <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
+                                            </a>
+                                        </div>
+                                        <div className="flex flex-row justify-between items-center pt-5 mb-8">
+                                            <span className="text-xl text-gray-300">Experimental Build</span>
+                                            <a href={getDownloadLink(urls.exp)}>
+                                                <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
+                                            </a>
+                                        </div>
+                                    </>
+                                )}
                         </div>
                     </div>
                 </div>

--- a/src/components/projects/A32NX/Download.tsx
+++ b/src/components/projects/A32NX/Download.tsx
@@ -1,10 +1,6 @@
 import { Button } from '../../utils/Button';
 
-type DownloadProps = {
-    expOnHold?: boolean
-}
-
-export const Download = ({ expOnHold }: DownloadProps) => {
+export const Download = ({ expOnHold }: { expOnHold?: boolean }) => {
     const urls = {
         stable: 'https://flybywiresim-packages.b-cdn.net/stable/A32NX-stable.zip',
         dev: 'https://flybywiresim-packages.b-cdn.net/vmaster/A32NX-master.zip',
@@ -70,38 +66,26 @@ export const Download = ({ expOnHold }: DownloadProps) => {
                                         <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
                                     </a>
                                 </div>
-                                <div />
-                            </div>
-                            {expOnHold
-                                ? (
-                                    <>
-                                        <div className="flex flex-row justify-between items-center pt-5 mb-5">
-                                            <span className="text-xl text-gray-300">Experimental Build</span>
-                                            <Button className="float-right w-40 font-bold bg-blue-light-contrast opacity-30 cursor-not-allowed">On Hold</Button>
-                                        </div>
+                                <div>
+                                    <div className="flex flex-row justify-between items-center pt-5 mb-8">
+                                        <span className="text-xl text-gray-300">Experimental Build</span>
+                                        <a href={expOnHold ? undefined : getDownloadLink(urls.exp)}>
+                                            <Button
+                                                className={`float-right w-40 font-bold bg-blue-light-contrast ${expOnHold ? 'opacity-30 cursor-not-allowed' : 'hover:bg-blue-medium'}`}
+                                            >
+                                                Download
+                                            </Button>
+                                        </a>
+                                    </div>
+                                    {expOnHold && (
                                         <span className="flex-wrap mb-8 text-gray-300">
                                             Our experimental branch is temporarily
                                             <a href="https://docs.flybywiresim.com/fbw-a32nx/support/exp/" className="text-blue-light">&#32;on hold&#32;</a>
                                             and all of its features have been moved to the development build.
                                         </span>
-                                    </>
-                                )
-                                : (
-                                    <>
-                                        <div className="flex flex-row justify-between items-center pt-5 mb-5">
-                                            <span className="text-xl text-gray-300">Development Build</span>
-                                            <a href={getDownloadLink(urls.dev)}>
-                                                <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
-                                            </a>
-                                        </div>
-                                        <div className="flex flex-row justify-between items-center pt-5 mb-8">
-                                            <span className="text-xl text-gray-300">Experimental Build</span>
-                                            <a href={getDownloadLink(urls.exp)}>
-                                                <Button className="float-right w-40 font-bold bg-blue-light-contrast hover:bg-blue-medium">Download</Button>
-                                            </a>
-                                        </div>
-                                    </>
-                                )}
+                                    )}
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/pages/a32nx.tsx
+++ b/src/pages/a32nx.tsx
@@ -8,7 +8,7 @@ const A32nx = () => (
         <Hero />
         <Features />
         <ExtendedFeatures />
-        <Download />
+        <Download expOnHold />
     </>
 );
 


### PR DESCRIPTION
## Summary of changes
Add conditional rendering to disable the experimental download link.
The link can be disabled by adding the `expOnHold` prop to the `Download` component in `src\pages\a32nx.tsx`

## Screenshots(if applicable)
**Before:**
![image](https://user-images.githubusercontent.com/58574351/144495023-a85867bf-ea3e-420f-bbbe-c6adaa1ca999.png)


**After:**
![image](https://user-images.githubusercontent.com/58574351/144654462-e0ec4c4e-3724-450f-aaa2-1b9a719bef3f.png)
