### PR TITLE
refactor: dynamic footer year 

### DIFF
--- a/src/components/utils/Footer.tsx
+++ b/src/components/utils/Footer.tsx
@@ -10,6 +10,8 @@ type IconItemProp = {
     href?: string
 }
 
+const year = new Date().getFullYear();
+
 export const FooterIconItem = (props: IconItemProp) => (
     <a href={props.href} target="_blank" rel="noreferrer">
         <FontAwesomeIcon className="hover:text-blue-light transition" icon={props.icon} size="lg" />
@@ -61,7 +63,7 @@ export const Footer = () => (
                     <Image src="/svg/vercel.svg" alt="Vercel" width={60} height={20} />
                 </span>
             </a>
-            <em className="text-center text-teal-100">&copy; FlyByWire Simulations and its contributors 2020-2021</em>
+            <em className="text-center text-teal-100">&copy; FlyByWire Simulations and its contributors 2020-{year}</em>
         </Container>
     </footer>
 );


### PR DESCRIPTION
## Summary of changes
< Provide a summary of the changes in this pull request, ensure that all changes are explained. >
Changes the copyright year in the footer to be dynamic such that it never needs to be manually updated. 

## Screenshots(if applicable)
< Provide screenshots of the affected areas if applicable to support your changes being made ensuring you show the full scope of the area changed and surrounding content, this allows for faster reviews on PRs. >
![image](https://user-images.githubusercontent.com/52870481/183238794-758cad37-0db0-432d-a17e-b5d88c7900ec.png)


HowNowBrownCrow#2591