### PR TITLE
chore: move A32NX video to cloudflare

### DIFF
--- a/src/components/home/A320Header.tsx
+++ b/src/components/home/A320Header.tsx
@@ -14,7 +14,7 @@ export const A320Header = () => {
         <header>
             <video
                 className="fixed -z-10 h-screen w-screen object-cover opacity-10"
-                src="https://cdn.flybywiresim.com/assets/website/video/A32NX.mp4"
+                src="https://flybywirecdn.com/assets/website/video/A32NX.mp4"
                 playsInline
                 autoPlay
                 muted

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -13,7 +13,7 @@ const Custom404 = () => (
 
         <video
             className="absolute top-0 h-screen w-screen object-cover opacity-10"
-            src="https://cdn.flybywiresim.com/assets/website/video/A32NX.mp4"
+            src="https://flybywirecdn.com/assets/website/video/A32NX.mp4"
             playsInline
             autoPlay
             muted


### PR DESCRIPTION
- moves A32NX video source location from BunnyCDN to Cloudflare R2