### PR TITLE
fix: removes dots above map markers

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -31,3 +31,7 @@
 .full-page-map .leaflet-control-zoom {
   margin-top: 72px !important;
 }
+
+.leaflet-div-icon {
+  border: none !important; 
+}


### PR DESCRIPTION
Removes the dots above all map markers, due to leaftet default css inluding a border on the .leaflet-div-icon class.
Class used to place markers (planes) on the map.

Before:
![image](https://github.com/user-attachments/assets/871e291b-af93-4589-b25b-8ff82504c6b1)

After:
![image](https://github.com/user-attachments/assets/b55f066b-810d-411a-8297-5addbfbf8422)
