### PR TITLE
feat: add press kit link to footer

### DIFF
--- a/src/components/Navigation/Footer.tsx
+++ b/src/components/Navigation/Footer.tsx
@@ -59,6 +59,7 @@ const Footer = () => (
                                 <NavItem label="Facebook" href={links.facebook} />
                                 <NavItem label="YouTube" href={links.youtube} />
                                 <NavItem label="Twitch" href={links.twitch} />
+                                <NavItem label="Press Kit" href={links.pressKit} />
                             </NavWrapper>
                         </div>
                     </div>

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -7,4 +7,5 @@ export const links: {[name: string]: string} = {
     facebook: 'https://www.facebook.com/FlyByWireSimulations/',
     opencollective: 'https://opencollective.com/flybywire',
     docsfaq: 'https://docs.flybywiresim.com/faq',
+    pressKit: 'https://github.com/flybywiresim/branding',
 };


### PR DESCRIPTION
## Summary of changes
Adds press kit link to footer section for quick and visible access to branding policies. 

## Screenshots(if applicable)
![image](https://github.com/user-attachments/assets/e3b203c4-d477-44b5-854e-a1fde7334914)