### PR TITLE
Fix: Bad link to the A32NX page in the footer

### DIFF
--- a/src/components/Navigation/Footer.tsx
+++ b/src/components/Navigation/Footer.tsx
@@ -40,7 +40,7 @@ const Footer = () => (
                         <div className="grid grid-cols-3 items-start gap-x-32 gap-y-5">
                             <NavWrapper label="Projects">
                                 <NavItem label="Installer" href={links.installer} />
-                                <NavItem label="A32NX" href="/projects/downloadLinks" />
+                                <NavItem label="A32NX" href="/projects/a32nx" />
                                 <NavItem label="A380X" href="/projects/a380x" />
                                 <NavItem label="EFB" href={links.efb} />
                             </NavWrapper>


### PR DESCRIPTION
Fixes #537

## Summary of changes
Fixes the issue with the wrong link to the A32NX page.

